### PR TITLE
LINE BOTが返すメッセージをよりリッチにし, 一番よいカフェを返す機能を追加

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -38,7 +38,7 @@ class WebhookController < ApplicationController
           api = GnaviRequest.new
           message = {
               type: 'text',
-              text: api.cafe_with_wifi(event['latitude'], event['longitude'])
+              text: api.cafe_with_wifi(event['message']['latitude'], event['message']['longitude'])
           }
           client.reply_message(event['replyToken'], message)
         end

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -35,7 +35,7 @@ class WebhookController < ApplicationController
           tf.write(response.body)
 
         when Line::Bot::Event::MessageType::Location
-          api = GnaviRestSearchAPI.new
+          api = GnaviRequest.new
           message = {
               type: 'text',
               text: api.cafe_with_wifi(event['latitude'], event['longitude'])

--- a/app/lib/gnavi_request.rb
+++ b/app/lib/gnavi_request.rb
@@ -20,7 +20,13 @@ class GnaviRequest
         messages.push(cafe)
       end
     }
-    messages[0]['name']
+
+    if messages.empty?
+      return '近くにWiFiが利用できるカフェが見つかりませんでした。'
+    end
+
+    cafe = messages.sample['name']
+    '近くのWiFiが利用できるカフェは【%s】' % cafe
 
   end
 

--- a/app/lib/gnavi_request.rb
+++ b/app/lib/gnavi_request.rb
@@ -13,7 +13,9 @@ class GnaviRequest
     begin
       response = OpenURI.open_uri(url).read
       return JSON.parse(response)
-    rescue Exception
+
+    rescue OpenURI::HTTPError => e
+      Rails.logger.info(e)
       return false
     end
 

--- a/app/lib/gnavi_request.rb
+++ b/app/lib/gnavi_request.rb
@@ -9,8 +9,14 @@ GNAVI_REST_SEARCH_BASE_URL = 'https://api.gnavi.co.jp/RestSearchAPI/v3'
 class GnaviRequest
   def gnavi_rest_search(latitude, longitude)
     url = '%s/?keyid=%s&category_l=RSFST18000&range=2&latitude=%s&longitude=%s&hit_per_page=50' % [GNAVI_REST_SEARCH_BASE_URL, GNAVI_API_KEY, latitude, longitude]
-    response = OpenURI.open_uri(url).read
-    JSON.parse(response)
+
+    begin
+      response = OpenURI.open_uri(url).read
+      return JSON.parse(response)
+    rescue Exception
+      return false
+    end
+
   end
 
   def response_processing(hash)
@@ -20,10 +26,6 @@ class GnaviRequest
         messages.push(cafe)
       end
     }
-
-    if messages.empty?
-      return '近くにWiFiが利用できるカフェが見つかりませんでした。'
-    end
 
     cafe = messages.sample
     "近くのWiFiが利用できるカフェ\n\n【%s】\n\n%s" % [cafe['name'], cafe['url_mobile']]
@@ -44,11 +46,28 @@ class GnaviRequest
 
   # Level2ではWiFiの使えるカフェをここに追加
   def cafe_with_wifi_list
-    %w(スターバックスコーヒー ドトール プロント タリーズ マクドナルド ウエシマコーヒー ロッテリア フレッシュネス コメダコーヒー)
+    [
+        'スターバックスコーヒー',
+        'ドトール',
+        'プロント',
+        'タリーズ',
+        'マクドナルド',
+        'ウエシマコーヒー',
+        'ロッテリア',
+        'フレッシュネス',
+        'コメダコーヒー',
+        'ベローチェ',
+        'エクセルシオール',
+    ]
   end
 
 
   def cafe_with_wifi(latitude, longitude)
-    response_processing(gnavi_rest_search(latitude, longitude))
+    response = gnavi_rest_search(latitude, longitude)
+    if response
+      response_processing(response)
+    else
+      '近くにWiFiが利用できるカフェが見つかりませんでした。'
+    end
   end
 end

--- a/app/lib/gnavi_request.rb
+++ b/app/lib/gnavi_request.rb
@@ -27,7 +27,7 @@ class GnaviRequest
       end
     }
 
-    cafe = messages.sample
+    cafe = choice_best(messages)
     "近くのWiFiが利用できるカフェ\n\n【%s】\n\n%s" % [cafe['name'], cafe['url_mobile']]
 
   end
@@ -42,6 +42,19 @@ class GnaviRequest
       end
     }
     result
+  end
+
+  # 一番よいカフェを選ぶ
+  # スタバ以外は...
+  def choice_best(cafes)
+    cafes.each { |cafe|
+      if cafe['name_kana'].include?('スターバックスコーヒー')
+        return cafe
+      end
+    }
+
+    cafes.sample
+
   end
 
   # Level2ではWiFiの使えるカフェをここに追加

--- a/app/lib/gnavi_request.rb
+++ b/app/lib/gnavi_request.rb
@@ -6,7 +6,7 @@ require 'json'
 GNAVI_API_KEY = ENV['GNAVI_API_KEY']
 GNAVI_REST_SEARCH_BASE_URL = 'https://api.gnavi.co.jp/RestSearchAPI/v3'
 
-class GnaviRestSearchAPI
+class GnaviRequest
   def gnavi_rest_search(latitude, longitude)
     url = '%s/?keyid=%s&category_l=RSFST18000&range=2&latitude=%s&longitude=%s&hit_per_page=50' % [GNAVI_REST_SEARCH_BASE_URL, GNAVI_API_KEY, latitude, longitude]
     response = OpenURI.open_uri(url).read
@@ -14,8 +14,33 @@ class GnaviRestSearchAPI
   end
 
   def response_processing(hash)
-    hash['rest'][0]['name']
+    messages = []
+    hash['rest'].each { |cafe|
+      if compare_cafe(cafe['name_kana'], cafe_with_wifi_list)
+        messages.push(cafe)
+      end
+    }
+    messages[0]['name']
+
   end
+
+  # cafe_with_wifi_listに含まれるカフェかどうかをチェック
+  def compare_cafe(name_kana, list)
+    result = false
+    list.each { |cafe|
+      if name_kana.include?(cafe)
+        result = true
+        break
+      end
+    }
+    result
+  end
+
+  # Level2ではWiFiの使えるカフェをここに追加
+  def cafe_with_wifi_list
+    %w(スターバックスコーヒー ドトール プロント タリーズ マクドナルド ウエシマコーヒー ロッテリア フレッシュネス コメダコーヒー)
+  end
+
 
   def cafe_with_wifi(latitude, longitude)
     response_processing(gnavi_rest_search(latitude, longitude))

--- a/app/lib/gnavi_request.rb
+++ b/app/lib/gnavi_request.rb
@@ -25,8 +25,8 @@ class GnaviRequest
       return '近くにWiFiが利用できるカフェが見つかりませんでした。'
     end
 
-    cafe = messages.sample['name']
-    '近くのWiFiが利用できるカフェは【%s】' % cafe
+    cafe = messages.sample
+    "近くのWiFiが利用できるカフェ\n\n【%s】\n\n%s" % [cafe['name'], cafe['url_mobile']]
 
   end
 

--- a/app/lib/gnavi_request.rb
+++ b/app/lib/gnavi_request.rb
@@ -22,7 +22,7 @@ class GnaviRequest
   def response_processing(hash)
     messages = []
     hash['rest'].each { |cafe|
-      if compare_cafe(cafe['name_kana'], cafe_with_wifi_list)
+      if has_wifi(cafe['name_kana'])
         messages.push(cafe)
       end
     }
@@ -33,9 +33,9 @@ class GnaviRequest
   end
 
   # cafe_with_wifi_listに含まれるカフェかどうかをチェック
-  def compare_cafe(name_kana, list)
+  def has_wifi(name_kana)
     result = false
-    list.each { |cafe|
+    cafe_with_wifi_list.each { |cafe|
       if name_kana.include?(cafe)
         result = true
         break

--- a/app/lib/gnavi_request.rb
+++ b/app/lib/gnavi_request.rb
@@ -8,7 +8,7 @@ GNAVI_REST_SEARCH_BASE_URL = 'https://api.gnavi.co.jp/RestSearchAPI/v3'
 
 class GnaviRestSearchAPI
   def gnavi_rest_search(latitude, longitude)
-    url = '%s/?keyid=%s&category_l=RSFST18000&range=4&latitude=%s&longitude=%s&wifi=1' % [GNAVI_REST_SEARCH_BASE_URL, GNAVI_API_KEY, latitude, longitude]
+    url = '%s/?keyid=%s&category_l=RSFST18000&range=2&latitude=%s&longitude=%s&hit_per_page=50' % [GNAVI_REST_SEARCH_BASE_URL, GNAVI_API_KEY, latitude, longitude]
     response = OpenURI.open_uri(url).read
     JSON.parse(response)
   end

--- a/app/lib/gnavi_request.rb
+++ b/app/lib/gnavi_request.rb
@@ -36,14 +36,7 @@ class GnaviRequest
 
   # cafe_with_wifi_listに含まれるカフェかどうかをチェック
   def has_wifi(name_kana)
-    result = false
-    cafe_with_wifi_list.each { |cafe|
-      if name_kana.include?(cafe)
-        result = true
-        break
-      end
-    }
-    result
+    !cafe_with_wifi_list.map { |cafe| cafe if name_kana.include?(cafe) }.compact.empty?
   end
 
   # 一番よいカフェを選ぶ


### PR DESCRIPTION
## 概要
メッセージにカフェの名前とモバイルサイトのURLを付随して返すようにした.
また, 一番良いと思われるカフェを提案するようにした.

## Level1での位置情報について
feature-level1では位置情報を適切にパースできていなかった. そこで, Messaging APIから受け取るeventを適切にパースし現在地付近のカフェを取得するように修正した.

## WiFiありのカフェについて
ぐるなびAPIをwifi=1をクエリーパラメーターとして指定すると, 代表的なカフェを取得できない(例: スターバックスコーヒー, ドトール, タリーズ等)ことがわかったため, 自分自身でWiFiの使用できるカフェをまとめてリストを作成した.

## 一番よいカフェについて
一番よいカフェとはスターバックスである.